### PR TITLE
Use idToken claims instead of UserInfo on Profile page

### DIFF
--- a/custom-login/src/components/Profile.vue
+++ b/custom-login/src/components/Profile.vue
@@ -57,7 +57,8 @@ export default {
     }
   },
   async created () {
-    this.claims = await Object.entries(await this.$auth.getUser()).map(entry => ({ claim: entry[0], value: entry[1] }))
+    const idToken = await this.$auth.tokenManager.get('idToken')
+    this.claims = await Object.entries(idToken.claims).map(entry => ({ claim: entry[0], value: entry[1] }))
   }
 }
 </script>

--- a/okta-hosted-login/src/components/Profile.vue
+++ b/okta-hosted-login/src/components/Profile.vue
@@ -57,7 +57,8 @@ export default {
     }
   },
   async created () {
-    this.claims = await Object.entries(await this.$auth.getUser()).map(entry => ({ claim: entry[0], value: entry[1] }))
+    const idToken = await this.$auth.tokenManager.get('idToken')
+    this.claims = await Object.entries(idToken.claims).map(entry => ({ claim: entry[0], value: entry[1] }))
   }
 }
 </script>


### PR DESCRIPTION
The "My User Profile (ID Token Claims)" does not actually contain all of the claims in the Id Token.

Looks like the previous logic used the user info instead?